### PR TITLE
Fix

### DIFF
--- a/src/WaypointNav.cpp
+++ b/src/WaypointNav.cpp
@@ -163,15 +163,6 @@ void WaypointNav::Run()
                                       waypoint_index_, robot_pose_, waypoint_area_threshold_,
                                       node_name_, way_sound_))
         way_srv_->setWaypoint(goal_, waypoint_csv_, waypoint_index_, ac_move_base_);
-        way_srv_->setWaypoint(goal_, waypoint_csv_, waypoint_index_, ac_move_base_);
-        way_srv_->setWaypoint(goal_, waypoint_csv_, waypoint_index_, ac_move_base_);
-        way_srv_->setWaypoint(goal_, waypoint_csv_, waypoint_index_, ac_move_base_);
-        way_srv_->setWaypoint(goal_, waypoint_csv_, waypoint_index_, ac_move_base_);
-        way_srv_->setWaypoint(goal_, waypoint_csv_, waypoint_index_, ac_move_base_);
-        way_srv_->setWaypoint(goal_, waypoint_csv_, waypoint_index_, ac_move_base_);
-        way_srv_->setWaypoint(goal_, waypoint_csv_, waypoint_index_, ac_move_base_);
-        way_srv_->setWaypoint(goal_, waypoint_csv_, waypoint_index_, ac_move_base_);
-        way_srv_->setWaypoint(goal_, waypoint_csv_, waypoint_index_, ac_move_base_);
     }
     else if (FinalGoalWaypointMode_)
       way_srv_->setWaypoint(goal_, waypoint_csv_, waypoint_index_, ac_move_base_);

--- a/src/WaypointNav_node.cpp
+++ b/src/WaypointNav_node.cpp
@@ -32,7 +32,8 @@ int main(int argc, char** argv)
   ROS_INFO("%s: Please ' rostopic pub  -1 /goal_command std_msgs/String go ' ",
            ros::this_node::getName().c_str());
 
-  ros::AsyncSpinner spinner(pnh.param("num_callback_threads", 1));
+  // If there is only one thread, the timer callback may not work well.
+  ros::AsyncSpinner spinner(pnh.param("num_callback_threads", 4));
   spinner.start();
   ros::waitForShutdown();
   return 0;


### PR DESCRIPTION
タイマーコールバック関数であるgetRobotPose()が上手く動くように修正。

動かなかった原因は、シングルスレッドだとタイマーコールバックの登録を行う前に
サブスクライバのコールバック関数の方が動作してしまうことだと考えている。

マルチスレッドにすることでサブスクライバのコールバック関数が動作しても、マルチスレッドなので
タイマーコールバックの登録を行う事ができると考えている。